### PR TITLE
Update clientInfoOverride string

### DIFF
--- a/Shared/libProvision/Apple Services/RPVLoginImpl.m
+++ b/Shared/libProvision/Apple Services/RPVLoginImpl.m
@@ -256,7 +256,7 @@ static NSData *createAppTokensChecksum(NSData *sk, NSString *adsid, NSArray<NSSt
     self = [super init];
     
     if (self) {
-        self.clientInfoOverride = @"<MacBookPro11,5> <Mac OS X;10.14.6;18G103> <com.apple.AuthKit/1 (com.apple.akd/1.0)>";
+        self.clientInfoOverride = @"<MacBookPro15,1> <Mac OS X;10.15.2;19C57> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>";
         
 #if TARGET_OS_IOS
         // Create rng pointer


### PR DESCRIPTION
[This commit](https://github.com/rileytestut/AltServer-Windows/commit/51374bee0a08b8d069f2b8e57a62b83c61878298) from the AltServer for Windows project provides the currently working client info string that should (hopefully) fix the “Session Expired” error. As of February 2020, AltServer is confirmed to be working with said client info.